### PR TITLE
fix(ci): change docker image tag to reflect new repo and impl job matrix

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,29 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
-  
-  publish-ch-app:
-    needs: release
-    if: ${{ needs.release.outputs.new_tag_version != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build Docker image
-        env:
-          DOCKER_IMAGE_TAG: ${{ needs.release.outputs.new_tag_version }}
-        run: cd clearing-house-app && docker build -t ghcr.io/truzzt/ids-basecamp-clearing/ch-app:$DOCKER_IMAGE_TAG .
-
-      - name: Push Docker image
-        env:
-          DOCKER_IMAGE_TAG: ${{ needs.release.outputs.new_tag_version }}
-        run: docker push ghcr.io/truzzt/ids-basecamp-clearing/ch-app:$DOCKER_IMAGE_TAG
-
-  publish-ch-edc:
+  publish-docker-images:
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.new_tag_version != '' }}
@@ -62,6 +41,16 @@ jobs:
       contents: read
       packages: write
       id-token: write
+
+    strategy:
+      matrix:
+        include:
+          - context: "ch-app"
+            directory: "clearing-house-app"
+            dockerfile: "Dockerfile" 
+          - context: "ch-edc"
+            directory: "clearing-house-edc"
+            dockerfile: "launchers/connector-prod/Dockerfile"
 
     steps:
       - name: Checkout repository
@@ -73,9 +62,12 @@ jobs:
       - name: Build Docker image
         env:
           DOCKER_IMAGE_TAG: ${{ needs.release.outputs.new_tag_version }}
-        run: cd clearing-house-edc && docker build -t ghcr.io/truzzt/ids-basecamp-clearing/ch-edc:$DOCKER_IMAGE_TAG -f launchers/connector-prod/Dockerfile .
+        run: |
+          cd ${{ matrix.directory }}
+          docker build -t ghcr.io/${{ github.repository }}/${{ matrix.context }}:$DOCKER_IMAGE_TAG -f ${{ matrix.dockerfile }} .
 
       - name: Push Docker image
         env:
           DOCKER_IMAGE_TAG: ${{ needs.release.outputs.new_tag_version }}
-        run: docker push ghcr.io/truzzt/ids-basecamp-clearing/ch-edc:$DOCKER_IMAGE_TAG
+        run: docker push ghcr.io/${{ github.repository }}/${{ matrix.context }}:$DOCKER_IMAGE_TAG 
+


### PR DESCRIPTION
## What this PR changes/adds

Exchange the static docker image tags with GitHub action variables and implemented a job matrix to avoid repetition.

## Why it does that

The static docker image tags caused an error since the repository moved its location: [Action](https://github.com/ids-basecamp/clearinghouse/actions/runs/7739963388/job/21103891880) 

## Further notes

none

## Linked Issue(s)

none