### PR TITLE
docs: setup deployment docs

### DIFF
--- a/docs/content/admin-guide/deployment.md
+++ b/docs/content/admin-guide/deployment.md
@@ -1,0 +1,5 @@
+# Deployment
+
+## Production
+
+### Exposing .well-known route

--- a/docs/content/admin-guide/deployment.md
+++ b/docs/content/admin-guide/deployment.md
@@ -2,4 +2,14 @@
 
 ## Production
 
-### Exposing .well-known route
+### Publishing the .well-known Route
+The [ch-app](/ch-app_installation.md) makes the clearinghouse's public key accessible via the following route: /.well-known/jwks.json. To ensure proper routing, the reverse proxy must be configured to direct this path to the [ch-app](/ch-app_installation.md).
+
+**Example Traefik Configuration**
+
+For Docker:
+```
+deploy:
+  labels:
+    - traefik.http.routers.clearing-app-http.rule=Host(`${CLEARING_DOMAIN}`) && PathPrefix(`/.well-known/jwks.json`)
+```


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a deployment section to the documentation highlighting the .well-known route

## Why it does that

The /.well-known route can be used to verify the signature of the recipe from the clearinghouse or function as a health check for uptime.

## Linked Issue(s)

Mobility-Data-Space/MDS-Project#176